### PR TITLE
Fix: grpc response is slow at first when faiss-server restarting 

### DIFF
--- a/client_docker_run
+++ b/client_docker_run
@@ -1,0 +1,7 @@
+#ARGS="search-by-key 100 --host=<HOST>:80"
+ARGS="${@:1}"
+docker run -it --rm \
+  -v $(pwd):/app \
+  --entrypoint python \
+  --name faiss-server-client \
+  daangn/faiss-server:v20200814 client.py $ARGS


### PR DESCRIPTION
Use dictionary for checking request key is contained in faiss keys and finding index of the key.